### PR TITLE
 docs/clean_install_windows.md: Tell users not to download the ISO directly to their USB drive

### DIFF
--- a/docs/clean_install_windows.md
+++ b/docs/clean_install_windows.md
@@ -6,7 +6,7 @@ Guide on how to backup your data and clean install Windows.
 
 ## Prerequisites
 
-- A genuine Windows ISO file, you can download from https://msdl.gravesoft.dev/
+- A genuine Windows ISO file, you can download from https://msdl.gravesoft.dev/ (don't download the ISO directly to your USB drive)
 - The latest version of Rufus from https://rufus.ie/
 - A minimum 8GB USB drive  
 - Follow this [guide](remove_malware.md) before making a bootable USB if you think the system has malware.


### PR DESCRIPTION
The reasoning is that, beyond the fact it probably won't work, most USB sticks default to FAT32 (which has a 4gb file size limit), hence downloading large ISOs onto USB sticks will fail with a misleading "out of storage" error message